### PR TITLE
sort threading worker raise Queue Empty exception and some cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ out/
 *.csv
 
 .DS_Store
+
+.idea/


### PR DESCRIPTION
sort some code in aria.utils.threading

fix issue when FixedThreadPoolExecutor thread worker got Empty exception from Queue.Queue
the worker got stoped